### PR TITLE
Force expire on cookie deletion

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -111,7 +111,7 @@ module Sinatra
 
       def delete(key)
         result = self[key]
-        @response.delete_cookie(key.to_s, @options)
+        @response.delete_cookie(key.to_s, @options.merge(expires: Time.new(0)))
         result
       end
 


### PR DESCRIPTION
Currently, setting a `cookie_options` with a default `expires` date makes any deleted cookie to
be set with an empty value, but expiring on the said date, thus not being removed.

This forces a default Time 0 for all the deleted cookies so they will be removed from the browser.
